### PR TITLE
Add build discarder to options and remove cron

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ pipeline {
   }
   options {
     skipDefaultCheckout()
+    buildDiscarder(logRotator(numToKeepStr: '10'))
   }
   triggers {
     cron('H 23 * * *')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,9 +6,6 @@ pipeline {
     skipDefaultCheckout()
     buildDiscarder(logRotator(numToKeepStr: '10'))
   }
-  triggers {
-    cron('H 23 * * *')
-  }
   stages {
     stage('Checkout') {
       steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,9 @@ pipeline {
     skipDefaultCheckout()
     buildDiscarder(logRotator(numToKeepStr: '10'))
   }
+  triggers {
+    cron('0 23 * * *')
+  }
   stages {
     stage('Checkout') {
       steps {


### PR DESCRIPTION
This was building once a day and was starting to fill up the master ~12GB, 

This should enable old builds to be discarded and will only build if it detects a change.